### PR TITLE
Fixed (hopefully) tests failing based on execution order

### DIFF
--- a/src/test/java/de/stevenschwenke/java/ithubbs/ithubbsbackend/admin/event/group/AdminEventControllerTest.java
+++ b/src/test/java/de/stevenschwenke/java/ithubbs/ithubbsbackend/admin/event/group/AdminEventControllerTest.java
@@ -3,6 +3,8 @@ package de.stevenschwenke.java.ithubbs.ithubbsbackend.admin.event.group;
 import de.stevenschwenke.java.ithubbs.ithubbsbackend.admin.event.AdminEventController;
 import de.stevenschwenke.java.ithubbs.ithubbsbackend.admin.event.AdminEventService;
 import de.stevenschwenke.java.ithubbs.ithubbsbackend.event.Event;
+import de.stevenschwenke.java.ithubbs.ithubbsbackend.event.EventRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -88,5 +90,10 @@ class AdminEventControllerTest {
         ResponseEntity<?> response = adminEventController.deleteEvent(new Event());
 
         assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, response.getStatusCode());
+    }
+
+    @AfterEach
+    void tearDown(@Autowired EventRepository repository) {
+        repository.deleteAll();
     }
 }

--- a/src/test/java/de/stevenschwenke/java/ithubbs/ithubbsbackend/admin/event/group/AdminEventServiceImplTest.java
+++ b/src/test/java/de/stevenschwenke/java/ithubbs/ithubbsbackend/admin/event/group/AdminEventServiceImplTest.java
@@ -3,6 +3,8 @@ package de.stevenschwenke.java.ithubbs.ithubbsbackend.admin.event.group;
 import de.stevenschwenke.java.ithubbs.ithubbsbackend.admin.event.AdminEventRepository;
 import de.stevenschwenke.java.ithubbs.ithubbsbackend.admin.event.AdminEventServiceImpl;
 import de.stevenschwenke.java.ithubbs.ithubbsbackend.event.Event;
+import de.stevenschwenke.java.ithubbs.ithubbsbackend.event.EventRepository;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -92,5 +94,10 @@ class AdminEventServiceImplTest {
         adminEventService.deleteEvent(savedEvent);
 
         assertEquals(0, eventRepository.count());
+    }
+
+    @AfterAll
+    static void afterAll(@Autowired EventRepository repository) {
+        repository.deleteAll();
     }
 }

--- a/src/test/java/de/stevenschwenke/java/ithubbs/ithubbsbackend/admin/group/AdminGroupControllerTest.java
+++ b/src/test/java/de/stevenschwenke/java/ithubbs/ithubbsbackend/admin/group/AdminGroupControllerTest.java
@@ -1,6 +1,8 @@
 package de.stevenschwenke.java.ithubbs.ithubbsbackend.admin.group;
 
 import de.stevenschwenke.java.ithubbs.ithubbsbackend.group.Group;
+import de.stevenschwenke.java.ithubbs.ithubbsbackend.group.GroupRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -84,5 +86,10 @@ class AdminGroupControllerTest {
         ResponseEntity<?> response = adminGroupController.deleteGroup(new Group());
 
         assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, response.getStatusCode());
+    }
+
+    @AfterEach
+    void tearDown(@Autowired GroupRepository repository) {
+        repository.deleteAll();
     }
 }

--- a/src/test/java/de/stevenschwenke/java/ithubbs/ithubbsbackend/event/EventRepositoryTest.java
+++ b/src/test/java/de/stevenschwenke/java/ithubbs/ithubbsbackend/event/EventRepositoryTest.java
@@ -127,15 +127,16 @@ class EventRepositoryTest {
     @Test
     void onlyEventsInTheFutureAreReturned() {
 
-        Event today = new Event("today", ZonedDateTime.now(), "today");
-        Event yesterday = new Event("yesterday", ZonedDateTime.now().minusDays(1), "yesterday");
-        Event tomorrow = new Event("tomorrow", ZonedDateTime.now().plusDays(1), "tomorrow");
+        ZonedDateTime now = ZonedDateTime.now();
+        Event today = new Event("today", now, "today");
+        Event yesterday = new Event("yesterday", now.minusDays(1), "yesterday");
+        Event tomorrow = new Event("tomorrow", now.plusDays(1), "tomorrow");
 
         eventRepository.save(today);
         eventRepository.save(yesterday);
         eventRepository.save(tomorrow);
 
-        List<Event> events = eventRepository.findAllWithDatetimeAfter(ZonedDateTime.now());
+        List<Event> events = eventRepository.findAllWithDatetimeAfter(now.plusMinutes(1));
 
         assertEquals(1, events.size());
         assertEquals(tomorrow, events.get(0));


### PR DESCRIPTION
Fixes #2 
Admittedly these changes treat the symptoms rather than cause but at least the tests are running now (at least on my machine).
As a next step the `XYZControllerTest` classes should probably be refactored to use mocking.